### PR TITLE
delimitando api a solo get y lectura

### DIFF
--- a/gamesite/app/serializers.py
+++ b/gamesite/app/serializers.py
@@ -2,6 +2,9 @@ from .models import Categoria
 from rest_framework import serializers
 
 class CategoriaSerializer(serializers.ModelSerializer):
+    #Los siguientes campos los dejaremos como solo lectura ya que no queremos que accedan a estos
+    id_categoria = serializers.IntegerField(read_only=True)
+    nombre = serializers.CharField(read_only=True)
     class Meta:
         model = Categoria
         fields = ('__all__')

--- a/gamesite/app/views.py
+++ b/gamesite/app/views.py
@@ -15,6 +15,8 @@ from .models import Categoria, Juego
 class CategoriaViewSet(viewsets.ModelViewSet):
     serializer_class = CategoriaSerializer
     queryset = Categoria.objects.all()
+    #En la siguiente linea se especifica que metodos se podran ocupar en esta view
+    http_method_names = ['get']
 
 class MyPasswordChangeView(PasswordChangeView):
     form_class = PasswordChangeForm


### PR DESCRIPTION
Se delimito los metodos de la api a solo get ya que queremos que nuestro proyecto solo el superadmin y los supervisores podran modificar, agregar y eliminar estos datos, ademas se dejaron los campos id_categoria y nombre del modelo Categoria como solo lectura.